### PR TITLE
Handle process signals

### DIFF
--- a/src/utils.ml
+++ b/src/utils.ml
@@ -5,7 +5,8 @@ let run (com : string) : int * string list =
   let exit =
     match Unix.close_process_in ic with
     | WEXITED n -> n
-    | _ -> assert false
+    | WSIGNALED n -> failwith (Printf.sprintf "unexpected process termination by signal %d" n)
+    | WSTOPPED n -> failwith (Printf.sprintf "unexpected process stopped with signal %d" n)
   in
   exit, outputs
 


### PR DESCRIPTION
Replace the previous catch-all assert with explicit handling for WSIGNALED and WSTOPPED. Instead of an assert false for non-WEXITED cases, the code now raises descriptive failures including the signal number, improving diagnostics for unexpected process termination or stopping.