### PR TITLE
#13 arity mismatch between syscall and attack

### DIFF
--- a/src/sem.ml
+++ b/src/sem.ml
@@ -1110,6 +1110,13 @@ let rec graph_cmd ~vars ~proc:(proc : Subst.proc) ~syscaller find_def decls i (c
       in
       es, i_2, env
 
+and combine_pairs args es =
+  if List.length args <> List.length es then
+    invalid_arg
+      (Printf.sprintf "arity mismatch: expected %d arguments but got %d" (List.length args) (List.length es))
+  else
+    List.combine args es
+
 and graph_application ~vars ~proc ~syscaller find_def (decls : decl list) i (app : expr) : graph * Index.t * Env.t =
   let param = snd proc.pid in
   match app.desc with
@@ -1171,7 +1178,7 @@ and graph_application ~vars ~proc ~syscaller find_def (decls : decl list) i (app
                          ; source_vars = vars
                          ; pre = []
                          ; update = { (Update.update_unit ())
-                                      with items= List.combine args (List.map (fun e -> Update.New e) es) }
+                                      with items = combine_pairs args (List.map (fun e -> Update.New e) es) }
                          ; tag = []
                          ; post = []
                          ; target = ik
@@ -1222,7 +1229,7 @@ and graph_application ~vars ~proc ~syscaller find_def (decls : decl list) i (app
                ; source_vars = vars
                ; pre = []
                ; update = { (Update.update_unit ())
-                            with items = List.combine args (List.map (fun e -> Update.New e) es) }
+                            with items = combine_pairs args (List.map (fun e -> Update.New e) es) }
                ; tag = []
                ; post = []
                ; target = i0

--- a/src/typer.ml
+++ b/src/typer.ml
@@ -562,14 +562,16 @@ let rec type_decl base_fn env (d : Input.decl) : Env.t * Typed.decl list =
       env', [{ env; loc; desc = Syscall { id; args; cmd; attack } }]
   | DeclExtAttack (name, syscall, args, c) ->
       (* [attack id on syscall (a1,..,an) { c }] *)
-      let syscall =
+      let syscall, arity =
         match Env.find ~loc env syscall with
-        | syscall, ExtSyscall _ -> syscall
+        | syscall, ExtSyscall arity -> syscall, arity
         | id, desc ->
             error ~loc
             @@ InvalidVariable
                  { ident = id; def = desc; use = ExtSyscall (List.length args) }
       in
+      if List.length args <> arity then
+        error ~loc @@ ArityMismatch { arity; use = List.length args };
       let args, cmd =
         let env', args = extend_with_args env args @@ fun _id -> Var in
         let c = type_cmd env' c in

--- a/test/test.rab
+++ b/test/test.rab
@@ -225,6 +225,15 @@ requires
     reachable ::Valid()
 ]
 
+(*** TyperFail "Object of arity 2 takes 1 arguments" *)
+(* issue #13: arity mismatch between syscall and attack should give a proper error *)
+syscall send(c, v) {
+  put [c::store(v)]
+}
+attack eavesdrop_channel on send (c) {
+  skip
+}
+
 (*** Fail "unknown meta variable chan", TyperFail "Global channel chan cannot be used in an expression" *)
 type person_t : process
 type chan_t : channel


### PR DESCRIPTION
This pull request adds stricter arity checking for syscalls and their associated attacks, ensuring that the number of arguments matches the expected arity. It also introduces a helper function to improve code clarity and updates the test suite to cover the new error handling.

**Arity checking and error handling:**

* Added an explicit arity check in the typer for `DeclExtAttack` to raise a clear `ArityMismatch` error if the number of arguments in an attack does not match the syscall's arity.
* Updated the test suite (`test/test.rab`) to include a case where an attack provides the wrong number of arguments, verifying that the new error is triggered.

ISSUE: #13 