### PR TITLE
Add UnsupportedFact error and improve fact errors

### DIFF
--- a/src/loader.ml
+++ b/src/loader.ml
@@ -13,6 +13,7 @@ type error =
   | WrongInputType
   | NoBindingVariable
   | WrongChannelType of string * string
+  | UnsupportedFact of string
 
 exception Error of error Location.located
 
@@ -37,6 +38,7 @@ let print_error err ppf =
   | WrongInputType -> Format.fprintf ppf "wrong input type"
   | NoBindingVariable -> Format.fprintf ppf "no binding variable"
   | WrongChannelType (x, y) -> Format.fprintf ppf "%s type expected but %s given" x y
+  | UnsupportedFact s -> Format.fprintf ppf "unsupported fact form: %s" s
 
 let find_index f lst =
   let rec aux i = function
@@ -180,7 +182,7 @@ let process_fact_closed new_meta_vars ctx lctx f =
           ~loc:f.Location.loc
           (Syntax.FileFact (process_expr2 new_meta_vars ctx lctx e1,
                           process_expr2 new_meta_vars ctx lctx e2)))
-  | Input.ProcessFact _ -> assert false (* Unused *)
+  | Input.ProcessFact _ -> error ~loc (UnsupportedFact "process fact")
 ;;
 
 let process_facts_closed new_meta_vars ctx lctx fl =

--- a/src/typer.ml
+++ b/src/typer.ml
@@ -229,7 +229,7 @@ let type_fact env (fact : Input.fact) : Typed.fact =
   let loc = fact.loc in
   let desc : Typed.fact' =
     match fact.data with
-    | ProcessFact _ -> assert false (* Unused *)
+    | ProcessFact _ -> misc_errorf ~loc "process facts are not supported here"
     | Fact (name, es) ->
         (* Which fact? For strucure? *)
         let nes = List.length es in
@@ -240,7 +240,8 @@ let type_fact env (fact : Input.fact) : Typed.fact =
          | Some (Plain, Some arity) ->
              check_arity ~loc ~arity ~use:nes;
              Plain (name, List.map (type_expr env) es)
-         | Some (Plain, None) -> assert false
+         | Some (Plain, None) ->
+             misc_errorf ~loc "inconsistent arity information for fact %s" name
          | Some (desc, _) ->
              error ~loc @@ InvalidFact { name; def= desc; use= Plain }
         )


### PR DESCRIPTION
Replace brittle assert-false panics with explicit errors for unsupported fact forms and inconsistent arity.