### PR TITLE
Fix: Apply "sort_uniq" to persistent facts

### DIFF
--- a/src/spthy.ml
+++ b/src/spthy.ml
@@ -134,8 +134,8 @@ type fact' =
   }
 
 let dedup_persistent facts' =
-  let linears, persists = List.partition (fun f' -> f'.config.persist) facts' in
-  linears @ List.sort_uniq compare persists
+  let persists, linears = List.partition (fun f' -> f'.config.persist) facts' in
+  (List.sort_uniq compare persists) @ linears
 
 let fact' f : fact' =
   let with_param (param : Subst.param_id option) =


### PR DESCRIPTION
Duplicate persistent facts should be removed, but I found linear ones are currently removed.